### PR TITLE
Complete ARIA landmarks and skip links implementation

### DIFF
--- a/src/frontend/App.vue
+++ b/src/frontend/App.vue
@@ -8,7 +8,7 @@ console.log("App.vue is being loaded");
 <template>
   <div class="min-h-screen bg-background text-foreground">
     <RdLayoutHeader />
-    <main id="main">
+    <main id="main" role="main">
       <RouterView />
     </main>
     <RdLayoutFooter />

--- a/src/frontend/components/rd/layout/Footer.vue
+++ b/src/frontend/components/rd/layout/Footer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 
 <template>
-  <footer class="border-t bg-background/95">
+  <footer role="contentinfo" class="border-t bg-background/95">
     <div
       class="container py-8 flex flex-col md:flex-row items-center justify-between gap-4 text-sm text-muted-foreground"
     >

--- a/src/frontend/components/rd/layout/Header.vue
+++ b/src/frontend/components/rd/layout/Header.vue
@@ -49,7 +49,7 @@ const isActive = (to?: RouteTo) => {
 
       <!-- Desktop Navigation -->
       <nav
-        aria-label="Primary"
+        aria-label="Main navigation"
         class="hidden md:flex items-center gap-6 text-sm font-medium flex-1 min-w-0"
       >
         <RouterLink


### PR DESCRIPTION
## Summary

Completes the ARIA landmarks and skip links implementation to address critical accessibility requirements.

- ✅ Add `role="main"` to main content area in App.vue
- ✅ Add `role="contentinfo"` to footer element 
- ✅ Improve navigation aria-label from "Primary" to "Main navigation"
- ✅ Skip link component was already implemented and working correctly
- ✅ All major page sections now have proper ARIA landmark structure

This addresses issue #31 and provides critical accessibility improvements for screen reader users and keyboard navigation.

## Test plan

- [x] Build succeeds without errors
- [x] All tests pass (22/22)
- [x] Generated HTML contains proper ARIA landmarks:
  - `<main id="main" role="main">` 
  - `<footer role="contentinfo">`
  - `<nav aria-label="Main navigation">`
  - Skip link: `<a href="#main" class="sr-only focus:not-sr-only...">`
- [x] Linting and formatting checks pass

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)